### PR TITLE
Fix run status retrieval

### DIFF
--- a/src/server/trpc/procedures/sendChatMessage.ts
+++ b/src/server/trpc/procedures/sendChatMessage.ts
@@ -75,11 +75,11 @@ export const sendChatMessage = baseProcedure
       });
 
       // Wait for the run to complete
-      let runStatus = await openai.beta.threads.runs.retrieve(run.id, { thread_id: threadId });
+      let runStatus = await openai.beta.threads.runs.retrieve(threadId, run.id);
 
       while (runStatus.status === "in_progress" || runStatus.status === "queued") {
         await new Promise(resolve => setTimeout(resolve, 1000));
-        runStatus = await openai.beta.threads.runs.retrieve(run.id, { thread_id: threadId });
+        runStatus = await openai.beta.threads.runs.retrieve(threadId, run.id);
       }
 
       if (runStatus.status === "failed") {


### PR DESCRIPTION
## Summary
- fix thread run retrieval calls in `sendChatMessage`

## Testing
- `npx eslint . -c eslint.config.mjs --max-warnings 0` *(fails: 229 errors)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_688734e9fc28832985323b1befaed1d2