### PR TITLE
Fix openai response format schema

### DIFF
--- a/src/server/trpc/procedures/completeChatSession.ts
+++ b/src/server/trpc/procedures/completeChatSession.ts
@@ -116,9 +116,12 @@ export const completeChatSession = baseProcedure
         }
       ],
       response_format: {
-        type: 'json_object',
-        schema: anamnesisJsonSchema,
-      } as any
+        type: 'json_schema',
+        json_schema: {
+          name: 'anamnesis',
+          schema: anamnesisJsonSchema,
+        }
+      }
     });
 
     const responseContent = response.choices[0]?.message?.content;


### PR DESCRIPTION
Fixes OpenAI API `response_format` by changing `type` to `json_schema` and restructuring the schema definition for correct structured output.

The previous configuration used `type: 'json_object'` with a `schema` property, which is an invalid combination according to OpenAI API documentation. This would have caused the API to ignore the schema or fail. The change correctly configures the `response_format` to use `type: 'json_schema'` and nests the schema under `json_schema`, ensuring the API properly enforces the desired output structure.

---

[Open in Web](https://cursor.com/agents?id=bc-de7e5c8f-dd94-4502-914a-0e3514fbe061) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-de7e5c8f-dd94-4502-914a-0e3514fbe061) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)