### PR TITLE
Upgrade Node to 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Sokrates AI er en intelligent samtaleassistent som hjelper pasienter med å fyll
 ## 🚀 Kom i gang
 
 ### Forutsetninger
-- Node.js (v18 eller nyere)
+- Node.js (v22 eller nyere)
 - Docker og Docker Compose
 - OpenAI API-nøkkel
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes curl wget && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash && \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes nodejs && \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes wget build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev vim less iputils-ping sudo libsecret-1-0 command-not-found rsync man-db netcat-openbsd dnsutils procps lsof tini && \
     DEBIAN_FRONTEND=noninteractive apt-get update


### PR DESCRIPTION
## Summary
- bump Node version from 20 to 22 in Dockerfile
- document Node.js v22 requirement in README

## Testing
- `pnpm lint` *(fails: Unsafe TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_68873dad2cd08329bebe65b6cbb5d538