### PR TITLE
Add OpenAI usage policy note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,12 @@ src/server/api/routers/rating.ts	Lagrer pasientens tilbakemeldinger.
 	•	Hver forespørsel til API inkluderer JWT Bearer-token.
 	•	Token valideres på alle beskyttede endepunkter.
 
+📑 OpenAI-brukspolicy
+        •       Alle OpenAI-kall skjer server-side slik at API-nøkkelen ikke eksponeres.
+        •       Nøklene lagres kun i miljøvariabler og skrives ikke til databasen.
+        •       Forespørsler inkluderer `user`-feltet med anonym sesjons-ID.
+        •       Se https://openai.com/policies/usage-policies for mer informasjon.
+
 ⸻
 
 🔁 Prompt-logikk

--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ Hver fullførte samtale genererer en strukturert anamnese med følgende felter:
 - **Klinikk-isolasjon**: Leger ser kun sesjoner fra sin egen klinikk
 - **Token-validering**: Alle API-kall valideres med JWT-tokens
 
+## 📑 OpenAI-brukspolicy
+
+- Alle kall til OpenAI skjer server-side og API-nøklene eksponeres aldri i
+  klienten.
+- Nøklene lagres kun i miljøvariabler og blir ikke lagret i databasen.
+- Forespørsler inkluderer `user`-feltet med anonym sesjons-ID i henhold til
+  retningslinjene.
+- Les mer i <https://openai.com/policies/usage-policies>.
+
 ## 🧪 Testing
 
 Applikasjonen inkluderer demo-data for testing:


### PR DESCRIPTION
## Summary
- document OpenAI usage policy compliance in README
- mention policy details in AGENTS guidance

## Testing
- `pnpm lint` *(fails: can't fetch Prisma engine binaries)*

------
https://chatgpt.com/codex/tasks/task_b_68875aae60148329ae72ae75b45d565c