### PR TITLE
Add user identifiers to OpenAI API calls

### DIFF
--- a/src/server/trpc/procedures/completeChatSession.ts
+++ b/src/server/trpc/procedures/completeChatSession.ts
@@ -105,6 +105,7 @@ export const completeChatSession = baseProcedure
     // Generate structured anamnesis using OpenAI Chat API
     const response = await openai.chat.completions.create({
       model: env.ANAMNESIS_MODEL,
+      user: `session-${input.sessionId}`,
       messages: [
         {
           role: "system",

--- a/src/server/trpc/procedures/sendChatMessage.ts
+++ b/src/server/trpc/procedures/sendChatMessage.ts
@@ -69,11 +69,13 @@ export const sendChatMessage = baseProcedure
       await openai.beta.threads.messages.create(threadId, {
         role: "user",
         content: input.message,
+        user: `session-${input.sessionId}`,
       });
 
       // Run the assistant
       const run = await openai.beta.threads.runs.create(threadId, {
         assistant_id: env.ASSISTANT_ID,
+        user: `session-${input.sessionId}`,
       });
 
       // Wait for the run to complete with a timeout


### PR DESCRIPTION
## Summary
- send `user: session-${input.sessionId}` when creating messages and runs
- pass the same identifier to the chat completion request

## Testing
- `pnpm install --frozen-lockfile` *(fails: Failed to fetch prisma engine binaries)*

------
https://chatgpt.com/codex/tasks/task_b_68875aa1ff0c832999b7afde695bacf7